### PR TITLE
LBP-1054 Position of non-dragging items

### DIFF
--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -645,7 +645,8 @@ function getBorderSpacing(el) {
   el = $(el);
 
   let css = el.css('border-spacing'); // '0px 0px'
-  let [horizontal, vertical] = css.split(' ');
+  const [horizontal, initialVertical] = css.split(' ');
+  const vertical = initialVertical === undefined ? horizontal : initialVertical;
 
   return {
     horizontal: parseFloat(horizontal),

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ember-sortable",
+  "name": "@lookbooks/ember-sortable",
   "version": "1.9.1",
   "description": "Sortable UI primitives for Ember.",
   "directories": {


### PR DESCRIPTION
This forks the ember-sortable package from version 1.9.1 and fixes a bug that was preventing the non-dragging items from being repositioned around the dragged item. The fix allows it to handle border-spacing values with only a single number (ex '0px').